### PR TITLE
Re-scales radial velocities

### DIFF
--- a/config/boss_config.yaml
+++ b/config/boss_config.yaml
@@ -25,6 +25,8 @@ model:
     ccf_keys: ['r', 'monopole', 'quadrupole']
     # whether to use ccf monopole only (i.e., assume real-space ccf is isotropic) (default False)
     assume_isotropic: True
+    # wether the ccf comes from a template or data
+    from_data: False
   # how to calculate the cross-correlation with matter entering in the model
   matter_ccf:
     # model to use for the matter ccf: options are 'template', 'linear_bias' or 'excursion_set'

--- a/victor/ccf_fit.py
+++ b/victor/ccf_fit.py
@@ -153,10 +153,18 @@ class CCFFit(CCFModel):
         # sense check the data
         if self.fixed_covmat:
             if not (covmat.shape == ((len(self.s) * len(self.poles_s), len(self.s) * len(self.poles_s)))):
-                raise InputError('Unexpected shape of (fixed) covariance matrix')
+                try:
+                    covmat = covmat[:len(self.s) * len(self.poles_s), :len(self.s) * len(self.poles_s)]
+                    print('Warning, (fixed) covariance matrix was cut down to match the number of selected multipoles')
+                except:
+                    raise InputError('Unexpected shape of (fixed) covariance matrix')
         else:
             if not (covmat.shape == ((len(self.beta_covmat), len(self.s) * len(self.poles_s), len(self.s) * len(self.poles_s)))):
-                raise InputError('Unexpected shape of (beta-varying) covariance matrix')
+                try:
+                    covmat = covmat[:, :len(self.s) * len(self.poles_s), :len(self.s) * len(self.poles_s)]
+                    print('Warning, (beta-varying) covariance matrix was cut down to match the number of selected multipoles')
+                except:
+                    raise InputError('Unexpected shape of (beta-varying) covariance matrix')
 
         self.covmat = covmat
         self.icov = np.linalg.inv(self.covmat)

--- a/victor/ccf_fit.py
+++ b/victor/ccf_fit.py
@@ -354,10 +354,32 @@ class CCFFit(CCFModel):
             The 2D covariance matrix used for this evaluation
         """
 
+        # override defaults with settings provided
+        fit_options = copy.deepcopy(self.fit_options)
+        for key in kwargs:
+            fit_options[key] = kwargs[key]
+        
         theory_vector = self.theory_multipole_vector(self.s, params, self.poles_s, **kwargs)
         data_vector = self.multipole_datavector(params.get('beta', None))
         cov = self.get_interpolated_covariance(params.get('beta', None))
         icov = self.get_interpolated_precision(params.get('beta', None))
+
+        # compute the chi-squared value according to Percival et al (2021) Eq. 56
+        if 'chisq' in fit_options['likelihood']:
+            if fit_options['likelihood']['chisq'].lower() == 'percival':
+                # ensure likelihood is assumed Gaussian
+                try:
+                    assert(fit_options['likelihood']['form'].lower() == 'gaussian')
+                except AssertionError:
+                    raise InputError('When using the Percival prescription for chi-square calculation, likelihood form must be Gaussian.')
+                # calculate the re-scaling factor for the covariance matrix
+                nmocks  = fit_options['likelihood'].get('nmocks', 1)
+                nparams = fit_options['likelihood']['nparams'] # we want it to fail if this is not provided
+                ndata = len(self.s) * len(self.poles_s)
+                B = (nmocks - ndata - 2) / ((nmocks - ndata - 1) * (nmocks - ndata - 4))
+                prefactor = (nmocks-1)*(1+B*(ndata-nparams)) / (nmocks-ndata+nparams-1)
+
+                icov /= prefactor
 
         return np.dot(np.dot(theory_vector - data_vector, icov), theory_vector - data_vector), cov
 

--- a/victor/ccf_model.py
+++ b/victor/ccf_model.py
@@ -632,8 +632,8 @@ class CCFModel:
             dvr_interp = _spline(np.append([0.01], reference_r), dvr, ext=3)
         else:
             # rescale as normal
-            vr_interp = _spline(np.append([0.01*rescaling_factor], rescaled_r), vr, ext=3)
-            dvr_interp = _spline(np.append([0.01*rescaling_factor], rescaled_r), dvr/rescaling_factor, ext=3)
+            vr_interp = _spline(np.append([0.01*rescaling_factor], rescaled_r), vr*rescaling_factor, ext=3)
+            dvr_interp = _spline(np.append([0.01*rescaling_factor], rescaled_r), dvr, ext=3)
         if model['rsd_model'] in ['streaming', 'dispersion']:
            sigma_v = params.get('sigma_v', 380)
 

--- a/victor/ccf_model.py
+++ b/victor/ccf_model.py
@@ -662,6 +662,14 @@ class CCFModel:
                     r = np.sqrt(s_perp**2 + r_par**2)
                     r_par =  (s_par - v_par * iaH_true) / (1 + iaH_true * vr_interp(r) / r)
                 r = np.sqrt(s_perp**2 + r_par**2)
+                #=============================================================================
+                # fixing underflow for specific combinations of parameters
+                # replace all values less than the tolerance value with next largest
+                tolerance = 1e-7
+                underflows = np.where(r<tolerance)[0]
+                for underflow in underflows:
+                    r[underflow]=np.partition(np.ravel(r), len(underflows))[len(underflows)]
+                #=============================================================================
                 mu_r = r_par / r
                 # now scale the dispersion function for AP dilation and then evaluate
                 sv_spl = si.RectBivariateSpline(self.r_for_sv * rescaling_factor, self.mu_for_sv, self.sv_rmu.T)

--- a/victor/excursion_set_profile.py
+++ b/victor/excursion_set_profile.py
@@ -87,7 +87,7 @@ class ExcursionSetProfile:
             #This function sets up CosmoMC-like settings, with one massive neutrino and helium set using BBN consistency
             pars.set_cosmology(H0=100*h, ombh2=ombh2, omch2=omch2, mnu=mnu, omk=0)
             # primordial amplitude As value not important as will be normalised later
-            pars.Initpower.set_params(As=2e-9, ns=ns, r=0)
+            pars.InitPower.set_params(As=2e-9, ns=ns, r=0)
             if z > 0:
                 pars.set_matter_power(redshifts=[z, 0.], kmax=2.0)
             else:


### PR DESCRIPTION
Fixes re-scaling of velocities in theory_xi(). Closes #19 
Also adds a missing option in boss_config.yaml to get r-space CCF from data. 